### PR TITLE
turn down the number of concurrent calls to 10

### DIFF
--- a/worker/src/utils/index.ts
+++ b/worker/src/utils/index.ts
@@ -9,4 +9,4 @@ export const resources = [
 	"newsletters"
 ] as const
 
-export const CONCURRENCY = 25
+export const CONCURRENCY = 10


### PR DESCRIPTION
when concurrency was 25 and i tried to update 10k posts locally, ghost would consistently crash about halfway through. this seems like it might fix it.